### PR TITLE
Remove non-unicode characters from .app.src

### DIFF
--- a/src/lhttpc.app.src
+++ b/src/lhttpc.app.src
@@ -24,7 +24,7 @@
 %%% ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %%% ----------------------------------------------------------------------------
 
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar Hellstrom <oscar@hellstrom.st>
 %%% @doc This is the specification for the lhttpc application.
 %%% @end
 {application, lhttpc,


### PR DESCRIPTION
When compiling under Erlang 19 with rebar:
```
Cloning into 'lhttpc'...
ERROR: Failed to extract name from .../lhttpc/src/lhttpc.app.src: {error, {error, {27, file_io_server, invalid_unicode}}}
```